### PR TITLE
added autoload, removed extra comma after homepage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,15 @@
         {
                 "name": "Masato Sogame (Pocket7878)",
                 "email": "poketo7878@gmail.com",
-                "homepage": "http://poketo7878.dip.jp",
+                "homepage": "http://poketo7878.dip.jp"
         }],
         "require": {
                 "php": ">=5.2.0",
                 "opauth/opauth": ">=0.2.0"
+        },
+        "autoload": {
+                "psr-0": {
+                        "": "."
+                }
         }
 }


### PR DESCRIPTION
Fixes this error:

```
Reading composer.json of http://github.com/pocket7878/opauth-flickr (master)Skipped branch master, "https://raw.github.com/pocket7878/opauth-flickr/7a1c926854e277cf724047103c4a0b00fc80fa73/composer.json" does not contain valid JSON
Parse error on line 11:
...78.dip.jp",        0
----------------------^
Expected one of: 'STRING'

  [RuntimeException]                                                                                                                      
  No valid composer.json was found in any branch or tag of http://github.com/pocket7878/opauth-flickr, could not load a package from it.  
```
