### PR TITLE
Don't autoload

### DIFF
--- a/FlickrStrategy.php
+++ b/FlickrStrategy.php
@@ -11,8 +11,6 @@
  * @license     MIT License
  */
 
-require_once 'vendor/autoload.php';
-
 class FlickrStrategy extends OpauthStrategy {
 
         /**


### PR DESCRIPTION
Composer takes care of autoloading. Don't try to do this yourself.

In the project where you want to use this package, create a composer.json and require this package. That will download THIS package to vendor/opauth/flickr (and all other dependancies)
So when requiring, the vendor/autoload.php doesn't exist.
